### PR TITLE
Fixed page number in sample app and minor fixes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 Number 42
+   Copyright 2016-2018 Number 42
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/library/src/main/java/de/number42/subsampling_pdf_decoder/PDFRegionDecoder.java
+++ b/library/src/main/java/de/number42/subsampling_pdf_decoder/PDFRegionDecoder.java
@@ -138,9 +138,7 @@ public class PDFRegionDecoder implements ImageRegionDecoder {
     matrix.setScale(scale/sampleSize,scale/sampleSize);
     matrix.postTranslate(-rect.left/sampleSize, -rect.top/sampleSize);
     Canvas canvas = new Canvas(bitmap);
-    if (backgroundColorPdf != 0) {
-      canvas.drawColor(backgroundColorPdf);
-    }
+    canvas.drawColor(backgroundColorPdf);
     canvas.drawBitmap(bitmap,0,0,null);
     page.render(bitmap, null, matrix, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY);
 

--- a/sample/src/main/java/de/number42/subsampling_pdf_decoder_sample/MainActivity.java
+++ b/sample/src/main/java/de/number42/subsampling_pdf_decoder_sample/MainActivity.java
@@ -19,7 +19,7 @@ import fr.castorflex.android.verticalviewpager.VerticalViewPager;
 /**
  * This class simply shows a pdf file within the activity
  */
-public class MainActivity extends AppCompatActivity implements ViewPager.OnPageChangeListener {
+public class MainActivity extends AppCompatActivity {
 
   /**
    * name of the pdf in assets folder
@@ -57,11 +57,29 @@ public class MainActivity extends AppCompatActivity implements ViewPager.OnPageC
     ButterKnife.bind(this);
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      pager.setOnPageChangeListener(this);
       animator.setDisplayedChild(1);
     } else {
       setPDF();
     }
+
+    pager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener(){
+      @Override
+      public void onPageSelected(int index) {
+        MainActivity.this.onPageSelected(index);
+      }
+    });
+
+  }
+
+
+  /**
+   * Callback method for the {@link #onPageSelected(int)} to handle setting the
+   * page number in the activity
+   * @param position the current position in the pager
+   */
+  private void onPageSelected(int position) {
+    this.currentPosition = position;
+    updatePageCounter();
   }
 
   /**
@@ -73,21 +91,6 @@ public class MainActivity extends AppCompatActivity implements ViewPager.OnPageC
     pagerAdapter = new PDFPagerAdapter(this, Utils.getFileFromAssets(this, pdfName));
     pager.setAdapter(pagerAdapter);
     updatePageCounter();
-  }
-
-  //listener functions
-  @Override public void onPageScrolled(int position, float positionOffset,
-      int positionOffsetPixels) {
-
-  }
-
-  @Override public void onPageSelected(int position) {
-    this.currentPosition = position;
-    updatePageCounter();
-  }
-
-  @Override public void onPageScrollStateChanged(int state) {
-
   }
 
   /**


### PR DESCRIPTION
- The page number has not been showing correctly in the sample app. 
- Also updated the license
- Deleted unnecessary check for background color. I couldn't find any case where it was necessary not to set Color.TRANSPARENT. Tested it with different background colors in the pdf and the viewpager. If there is a specific case where this check makes sense, just cherry pick.
