### PR TITLE
Clean up the manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,11 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="de.number42.subsampling_pdf_decoder">
-
-  <application android:allowBackup="true"
-      android:label="@string/app_name"
-      android:supportsRtl="true"
-  >
-
-  </application>
-
-</manifest>
+<manifest package="de.number42.subsampling_pdf_decoder" />


### PR DESCRIPTION
This leads to errors for consumers. Libraries should never declare an `application` since the Android gradle plugin tries to merge this with the one of the consumer.